### PR TITLE
Removed setup.py, added pyproject.toml.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,5 @@ lint:
 .PHONY: release
 release:
 	rm -rf dist
-	python setup.py sdist bdist_wheel
+	python -m build
 	twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=44", "wheel", "setuptools_scm[toml]>=3.4.3"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ mypy==0.750
 tox==3.14.1
 twine==3.1.1
 wheel==0.33.6
+build

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup(use_scm_version=True)


### PR DESCRIPTION
Should be built with `python3 -m build` since now.