### PR TITLE
Add variant of `echo_color_unified_diff` for precomputed diff results

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,22 @@
 This is a thin wrapper around `difflib.unified_diff` that Does The Right Thing
 for "No newline at eof".  The args are also simplified compared to `difflib`:
 
-```
+```py
 moreorless.unified_diff(
     astr: str,
     bstr: str,
     filename: str,
     n: int = 3,
-) -> str
+) -> str:
+    ...
 
 # raises moreorless.patch.PatchException
 moreorless.patch.apply_single_file(
     contents: str,
     patch: str,
     allow_offsets: bool = True,
-) -> str
+) -> str:
+    ...
 
 # uses click to write to stdout with colors
 moreorless.click.echo_color_unified_diff(
@@ -24,7 +26,14 @@ moreorless.click.echo_color_unified_diff(
     bstr: str,
     filename: str,
     n: int = 3
-) -> None
+) -> None:
+    ...
+
+# if you want to use unified_diff yourself first (e.g. in another process)
+moreorless.click.echo_color_precomputed_diff(
+    diff: str,
+) -> None:
+    ...
 ```
 
 # License

--- a/moreorless/click.py
+++ b/moreorless/click.py
@@ -24,6 +24,24 @@ def echo_color_unified_diff(astr: str, bstr: str, filename: str, n: int = 3) -> 
             click.secho(line, nl=False)
 
 
+def echo_color_precomputed_diff(diff: str) -> None:
+    """
+    Like `echo_color_unified_diff`, but for precomputed diff results.
+    """
+    for line in diff.splitlines(True):
+        # TODO benchmark and see if constructing the string up front is faster
+        if line.startswith("---") or line.startswith("+++"):
+            click.secho(line, bold=True, nl=False)
+        elif line.startswith("@@"):
+            click.secho(line, fg="cyan", nl=False)
+        elif line.startswith("-"):
+            click.secho(line, fg="red", nl=False)
+        elif line.startswith("+"):
+            click.secho(line, fg="green", nl=False)
+        else:
+            click.secho(line, nl=False)
+
+
 def main(afile: str, bfile: str) -> None:  # pragma: no cover
     echo_color_unified_diff(Path(afile).read_text(), Path(bfile).read_text(), afile)
 

--- a/moreorless/click.py
+++ b/moreorless/click.py
@@ -10,18 +10,7 @@ def echo_color_unified_diff(astr: str, bstr: str, filename: str, n: int = 3) -> 
     """
     Just like `moreorless.unified_diff` except using `click.secho`.
     """
-    for line in unified_diff(astr, bstr, filename, n).splitlines(True):
-        # TODO benchmark and see if constructing the string up front is faster
-        if line.startswith("---") or line.startswith("+++"):
-            click.secho(line, bold=True, nl=False)
-        elif line.startswith("@@"):
-            click.secho(line, fg="cyan", nl=False)
-        elif line.startswith("-"):
-            click.secho(line, fg="red", nl=False)
-        elif line.startswith("+"):
-            click.secho(line, fg="green", nl=False)
-        else:
-            click.secho(line, nl=False)
+    echo_color_precomputed_diff(unified_diff(astr, bstr, filename, n))
 
 
 def echo_color_precomputed_diff(diff: str) -> None:

--- a/moreorless/tests/click.py
+++ b/moreorless/tests/click.py
@@ -2,13 +2,29 @@ import unittest
 from typing import Any
 from unittest.mock import call, patch
 
-from ..click import echo_color_unified_diff
+from .. import unified_diff
+from ..click import echo_color_precomputed_diff, echo_color_unified_diff
 
 
 class ColorTest(unittest.TestCase):
     @patch("click.secho")
     def test_echo_color_unified_diff(self, secho: Any) -> None:
         echo_color_unified_diff("a\nb\n", "a\nc\n", "x")
+        secho.assert_has_calls(
+            [
+                call("--- a/x\n", bold=True, nl=False),
+                call("+++ b/x\n", bold=True, nl=False),
+                call("@@ -1,2 +1,2 @@\n", fg="cyan", nl=False),
+                call(" a\n", nl=False),
+                call("-b\n", fg="red", nl=False),
+                call("+c\n", fg="green", nl=False),
+            ]
+        )
+
+    @patch("click.secho")
+    def test_echo_color_precomputed_diff(self, secho: Any) -> None:
+        diff = unified_diff("a\nb\n", "a\nc\n", "x")
+        echo_color_precomputed_diff(diff)
         secho.assert_has_calls(
             [
                 call("--- a/x\n", bold=True, nl=False),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage==4.5.4
 flake8==3.7.9
 isort==4.3.21
 mypy==0.750
+parameterized==0.8.1
 tox==3.14.1
 twine==3.1.1
 wheel==0.33.6


### PR DESCRIPTION
For cases where `unified_diff()` was already called and a diff computed, it is useful to have a way to echo that in color without needing to recompute the difference. This does that. It also fixes the dev requirements so that a fresh venv can run the test suite.

If there is a better name than `echo_color_precomputed_diff`, I'm all ears. Or just change the name to whatever makes sense and land that. I'm looking to use this as part of omnilib/ufmt#4 so that the diff can be computed in a child process and returned up to the parent, and have the parent output the diff in color.