### PR TITLE
Reject structurally invalid hunks in patch application

### DIFF
--- a/moreorless/patch.py
+++ b/moreorless/patch.py
@@ -18,7 +18,7 @@ def apply_single_file(contents: str, patch: str, allow_offsets: bool = True) -> 
     return "".join(_apply_hunks(lines, hunks, allow_offsets))
 
 
-POSITION_LINE_RE = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+POSITION_LINE_RE = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@[^\n]*\n?")
 
 
 class PatchException(Exception):
@@ -31,7 +31,7 @@ class ContextException(PatchException):
 
 def _parse_position_line(position_line: str) -> List[int]:
     """Given an `@@` line, return the four numbers within."""
-    match = POSITION_LINE_RE.match(position_line)
+    match = POSITION_LINE_RE.fullmatch(position_line)
     if not match:
         raise PatchException(f"Position line {position_line!r} failed to parse")
     return [
@@ -49,6 +49,22 @@ class Hunk:
     lines: List[str] = field(default_factory=list)
 
 
+def _validate_hunk_counts(hunk: Hunk) -> None:
+    pos = hunk.position
+    assert pos is not None
+    body = [line for line in hunk.lines[1:] if not line.startswith("\\")]
+    old_count = sum(1 for line in body if line and line[0] in (" ", "-"))
+    new_count = sum(1 for line in body if line and line[0] in (" ", "+"))
+    if old_count != pos[1]:
+        raise PatchException(
+            f"Hunk header declares {pos[1]} old lines but body has {old_count}"
+        )
+    if new_count != pos[3]:
+        raise PatchException(
+            f"Hunk header declares {pos[3]} new lines but body has {new_count}"
+        )
+
+
 def _split_hunks(diff_lines: Sequence[str]) -> List[Hunk]:
     """
     Splits unified diff lines (after the file header) into hunks.
@@ -60,6 +76,7 @@ def _split_hunks(diff_lines: Sequence[str]) -> List[Hunk]:
         if line.startswith("@@"):
             # Start a new hunk
             if hunk:
+                _validate_hunk_counts(hunk)
                 hunks.append(hunk)
             hunk = Hunk(_parse_position_line(line))
         # There should not be '---' or '+++' lines here, they are stripped off
@@ -69,6 +86,7 @@ def _split_hunks(diff_lines: Sequence[str]) -> List[Hunk]:
         hunk.lines.append(line)
 
     if hunk and hunk.lines:
+        _validate_hunk_counts(hunk)
         hunks.append(hunk)
 
     return hunks

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -66,7 +66,11 @@ def test_exhaustive(context: int) -> None:
     [
         ("@@ -5 +9 @@", [5, 1, 9, 1]),
         ("@@ -5,2 +9,3 @@", [5, 2, 9, 3]),
+        ("@@ -5,2 +9,3 @@ some_function", [5, 2, 9, 3]),
+        ("@@ -5,2 +9,3 @@\n", [5, 2, 9, 3]),
+        ("@@ -5,2 +9,3 @@ some_function\n", [5, 2, 9, 3]),
         ("@@ invalid @@", None),
+        ("@@ -1 +1 @@ trailing garbage after newline\nextra", None),
     ],
 )
 def test_parse_position_line(line: str, expected: Optional[List[int]]) -> None:
@@ -77,12 +81,36 @@ def test_parse_position_line(line: str, expected: Optional[List[int]]) -> None:
         assert _parse_position_line(line) == expected
 
 
+def test_hunk_count_mismatch_new() -> None:
+    # Header says +1 new line, but body has 2 (context + addition)
+    lines = ["@@ -1 +1 @@\n", " a\n", "+b\n"]
+    with pytest.raises(PatchException, match="declares 1 new lines but body has 2"):
+        _split_hunks(lines)
+
+
+def test_hunk_count_mismatch_old() -> None:
+    # Header says -1 old line, but body has 2 (context + deletion)
+    lines = ["@@ -1 +1 @@\n", " a\n", "-b\n"]
+    with pytest.raises(PatchException, match="declares 1 old lines but body has 2"):
+        _split_hunks(lines)
+
+
+def test_hunk_count_valid_with_no_newline_marker() -> None:
+    # "No newline" markers should not count toward line totals
+    lines = ["@@ -1 +1 @@\n", "-a\n", "\\ No newline at end of file\n", "+b\n"]
+    result = _split_hunks(lines)
+    assert len(result) == 1
+
+
 @pytest.mark.parametrize(
     "diff,msg",
     [
-        ("---\n+++\n@@ -1 +1 @@\n-invalid\n", "Failed to apply with offset at 0"),
+        # Count mismatch caught in _split_hunks before apply
+        ("---\n+++\n@@ -1 +1 @@\n-invalid\n", "declares 1 new lines but body has 0"),
+        # Content mismatch caught at apply time
         ("---\n+++\n@@ -1 +1 @@\n invalid\n", "Failed to apply with offset at 0"),
-        ("---\n+++\n@@ -1 +1 @@\nxinvalid\n", "Unknown line 'xinvalid\\\\n' at 0"),
+        # Count mismatch: unknown line type contributes 0 to either count
+        ("---\n+++\n@@ -1 +1 @@\nxinvalid\n", "declares 1 old lines but body has 0"),
     ],
 )
 def test_exceptions(diff: str, msg: str) -> None:
@@ -93,9 +121,12 @@ def test_exceptions(diff: str, msg: str) -> None:
 @pytest.mark.parametrize(
     "diff,msg",
     [
-        ("---\n+++\n@@ -1 +1 @@\n-invalid\n", "DELETE fail at 0"),
+        # Count mismatch caught in _split_hunks before apply
+        ("---\n+++\n@@ -1 +1 @@\n-invalid\n", "declares 1 new lines but body has 0"),
+        # Content mismatch caught at apply time
         ("---\n+++\n@@ -1 +1 @@\n invalid\n", "EQUAL fail at 0"),
-        ("---\n+++\n@@ -1 +1 @@\nxinvalid\n", "Unknown line 'xinvalid\\\\n' at 0"),
+        # Count mismatch: unknown line type contributes 0 to either count
+        ("---\n+++\n@@ -1 +1 @@\nxinvalid\n", "declares 1 old lines but body has 0"),
     ],
 )
 def test_exceptions_no_offset(diff: str, msg: str) -> None:


### PR DESCRIPTION
Use re.fullmatch() for hunk header parsing so text before or after the
recognized pattern is not silently ignored. Add _validate_hunk_counts()
to enforce that the declared old/new line counts in the @@ header match
the actual body, catching count mismatches before apply rather than
failing with a confusing error mid-application.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>