### PR TITLE
Fix missing newline after \\ No newline at end of file marker in combined diff

### DIFF
--- a/moreorless/combined_types.py
+++ b/moreorless/combined_types.py
@@ -29,7 +29,7 @@ class Line:
             buf.append(self.line)
         if not self.line.endswith("\n"):
             buf.append("\n")
-            buf.append("\\ No newline at end of file")
+            buf.append("\\ No newline at end of file\n")
 
     def to_str(self, is_merge: bool) -> str:
         buf: List[str] = []

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -27,8 +27,8 @@ def test_line_mixed() -> None:
 
 def test_line_no_newline() -> None:
     li = Line((1, 1, 0, 0), "foo")
-    assert li.to_str(is_merge=True) == "-- foo\n\\ No newline at end of file"
-    assert li.to_str(is_merge=False) == "++ foo\n\\ No newline at end of file"
+    assert li.to_str(is_merge=True) == "-- foo\n\\ No newline at end of file\n"
+    assert li.to_str(is_merge=False) == "++ foo\n\\ No newline at end of file\n"
 
 
 def test_hunk_context() -> None:
@@ -156,6 +156,18 @@ def test_divergent_three_insert_same() -> None:
         Line((1, 1, 0), "b\n"),
         Line((0, 1, 0), "d\n"),
     ]
+
+
+def test_adjacent_no_newline_lines() -> None:
+    assert combined_diff(["a"], ["b"]) == """\
+--- a/file
++++ b/file
+@@ -1,1 +1,1 @@
+-a
+\\ No newline at end of file
++b
+\\ No newline at end of file
+"""
 
 
 def test_merge_not_actually_merge() -> None:


### PR DESCRIPTION
Adjacent no-newline lines were being glued together because the marker
lacked a trailing newline. Also adds a regression test for combined_diff(["a"], ["b"]).