### PR TITLE
Fix missing f-prefix on error strings in combined.py

### DIFF
--- a/moreorless/combined.py
+++ b/moreorless/combined.py
@@ -93,12 +93,12 @@ def _contributions(
     """
     if merge_mode:
         if len(to_files) != 1:
-            raise ValueError("Can't merge_mode=True with to_files={len(to_files)}")
+            raise ValueError(f"Can't merge_mode=True with to_files={len(to_files)}")
         common = to_files[0]
         rest = from_files
     else:
         if len(from_files) != 1:
-            raise ValueError("Can't merge_mode=False with from_files={len(from_files)}")
+            raise ValueError(f"Can't merge_mode=False with from_files={len(from_files)}")
         common = from_files[0]
         rest = to_files
 

--- a/tests/test_combined.py
+++ b/tests/test_combined.py
@@ -71,6 +71,17 @@ def test_contributions_exceptions() -> None:
         _contributions(["a", "b"], ["c", "d"], False)
 
 
+def test_contributions_exception_messages() -> None:
+    with pytest.raises(ValueError, match=r"from_files=0"):
+        _contributions([], ["c"], False)
+    with pytest.raises(ValueError, match=r"from_files=2"):
+        _contributions(["a", "b"], ["c"], False)
+    with pytest.raises(ValueError, match=r"to_files=0"):
+        _contributions(["a"], [], True)
+    with pytest.raises(ValueError, match=r"to_files=2"):
+        _contributions(["a"], ["c", "d"], True)
+
+
 def test_divergent_basic() -> None:
     assert combined_diff([""], ["a\n", "b\n"]) == """\
 --- a/file


### PR DESCRIPTION
Both ValueError messages used {len(...)} interpolation without the f prefix,
so the literal text was raised instead of the actual count.